### PR TITLE
20 api get articles pagination

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -246,7 +246,7 @@ describe("GET /api/articles", () => {
         expect(articles.length).toBe(0);
       });
   });
-  test("STATUS 200: returns an array of articles with a 'total_count' property, reflecting the total number of articles excluding the pagination limit", () => {
+  test("STATUS 200: returns an array of articles and a 'total_count' property reflecting the total number of articles excluding the pagination limit", () => {
     return request(app)
       .get("/api/articles?limit=1")
       .expect(200)
@@ -256,7 +256,7 @@ describe("GET /api/articles", () => {
         expect(total_count).not.toBe(articles.length);
       });
   });
-  test("STATUS 200: returns an array of articles with a 'total_count' property, reflecting the total number of articles after applying filters and excluding the pagination limit", () => {
+  test("STATUS 200: returns an array of articles and a 'total_count' property reflecting the total number of articles after applying filters and excluding the pagination limit", () => {
     return request(app)
       .get("/api/articles?limit=1&topic=mitch")
       .expect(200)

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -19,9 +19,9 @@ function getArticleById(req, res, next) {
 }
 
 function getAllArticles(req, res, next) {
-  const { topic, sort_by, order } = req.query;
+  const { topic, sort_by, order, limit, p } = req.query;
 
-  const promises = [selectAllArticles(topic, sort_by, order)];
+  const promises = [selectAllArticles(topic, sort_by, order, limit, p)];
 
   if (topic) {
     promises.push(selectTopicBySlug(topic));
@@ -29,9 +29,11 @@ function getAllArticles(req, res, next) {
 
   Promise.all(promises)
     .then((promisesResolution) => {
-      res.status(200).send({ articles: promisesResolution[0] });
+      res.status(200).send(promisesResolution[0]);
     })
-    .catch((err) => next(err));
+    .catch((err) => {
+      next(err);
+    });
 }
 
 function patchArticleById(req, res, next) {

--- a/endpoints.json
+++ b/endpoints.json
@@ -32,8 +32,8 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles sorted by created_at in descending order by default",
-    "queries": ["topic", "sort_by", "order"],
+    "description": "serves an object with an articles property (articles sorted by created_at in descending order by default) and a total_count property reflecting the total number of articles after applying filters and excluding the pagination limit",
+    "queries": ["topic", "sort_by", "order , p, limit"],
     "exampleResponse": {
       "articles": [
         {
@@ -56,7 +56,8 @@
           "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
           "comment_count": "1"
         }
-      ]
+      ],
+      "total_count": 13
     }
   },
   "POST /api/articles": {

--- a/endpoints.json
+++ b/endpoints.json
@@ -33,7 +33,7 @@
   },
   "GET /api/articles": {
     "description": "serves an array of all articles sorted by created_at in descending order by default",
-    "queries": ["author", "topic", "sort_by", "order"],
+    "queries": ["topic", "sort_by", "order"],
     "exampleResponse": {
       "articles": [
         {


### PR DESCRIPTION
Sometimes, I receive an error: 'deadlock detected' (test GET /api/articles STATUS 400: returns an error if the provided 'sort_by' is not valid)